### PR TITLE
Avoid std::function() overhead in arithmetic

### DIFF
--- a/doc/news/stdfunction.rst
+++ b/doc/news/stdfunction.rst
@@ -1,0 +1,3 @@
+**Performance:**
+
+* Speed up arithmetic between `renf_elem_class` in C++ interface.

--- a/libeantic/benchmark/Makefile.am
+++ b/libeantic/benchmark/Makefile.am
@@ -1,6 +1,6 @@
 noinst_PROGRAMS = benchmark
 
-benchmark_SOURCES = main.cpp renfxx/b-constructor.cpp
+benchmark_SOURCES = main.cpp renfxx/b-constructor.cpp renfxx/b-arithmetic.cpp
 
 benchmark_LDADD = $(builddir)/../srcxx/libeanticxx.la $(builddir)/../src/libeantic.la
 

--- a/libeantic/benchmark/renfxx/b-arithmetic.cpp
+++ b/libeantic/benchmark/renfxx/b-arithmetic.cpp
@@ -1,0 +1,96 @@
+/*
+    Copyright (C) 2021 Julian Rüth
+
+    This file is part of e-antic
+
+    e-antic is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3.0 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <benchmark/benchmark.h>
+
+#include "../../e-antic/renfxx.h"
+
+using benchmark::DoNotOptimize;
+using benchmark::State;
+
+namespace eantic {
+namespace benchmark {
+
+template <typename T>
+static void TrivialAddition(State& state)
+{
+    renf_elem_class lhs(2);
+    T rhs = T(2);
+
+    for (auto _ : state)
+    {
+        DoNotOptimize(lhs += rhs);
+    }
+}
+BENCHMARK_TEMPLATE(TrivialAddition, int);
+BENCHMARK_TEMPLATE(TrivialAddition, long);
+BENCHMARK_TEMPLATE(TrivialAddition, long long);
+BENCHMARK_TEMPLATE(TrivialAddition, mpz_class);
+BENCHMARK_TEMPLATE(TrivialAddition, mpq_class);
+BENCHMARK_TEMPLATE(TrivialAddition, renf_elem_class);
+
+template <typename T>
+static void TrivialMultiplication(State& state)
+{
+    renf_elem_class lhs(2);
+    T rhs = T(-1);
+
+    for (auto _ : state)
+    {
+        DoNotOptimize(lhs *= rhs);
+    }
+}
+BENCHMARK_TEMPLATE(TrivialMultiplication, int);
+BENCHMARK_TEMPLATE(TrivialMultiplication, long);
+BENCHMARK_TEMPLATE(TrivialMultiplication, long long);
+BENCHMARK_TEMPLATE(TrivialMultiplication, mpz_class);
+BENCHMARK_TEMPLATE(TrivialMultiplication, mpq_class);
+BENCHMARK_TEMPLATE(TrivialMultiplication, renf_elem_class);
+
+template <typename T>
+static void TrivialSubtraction(State& state)
+{
+    renf_elem_class lhs(2);
+    T rhs = T(2);
+
+    for (auto _ : state)
+    {
+        DoNotOptimize(lhs -= rhs);
+    }
+}
+BENCHMARK_TEMPLATE(TrivialSubtraction, int);
+BENCHMARK_TEMPLATE(TrivialSubtraction, long);
+BENCHMARK_TEMPLATE(TrivialSubtraction, long long);
+BENCHMARK_TEMPLATE(TrivialSubtraction, mpz_class);
+BENCHMARK_TEMPLATE(TrivialSubtraction, mpq_class);
+BENCHMARK_TEMPLATE(TrivialSubtraction, renf_elem_class);
+
+template <typename T>
+static void TrivialDivision(State& state)
+{
+    renf_elem_class lhs(2);
+    T rhs = T(-1);
+
+    for (auto _ : state)
+    {
+        DoNotOptimize(lhs /= rhs);
+    }
+}
+BENCHMARK_TEMPLATE(TrivialDivision, int);
+BENCHMARK_TEMPLATE(TrivialDivision, long);
+BENCHMARK_TEMPLATE(TrivialDivision, long long);
+BENCHMARK_TEMPLATE(TrivialDivision, mpz_class);
+BENCHMARK_TEMPLATE(TrivialDivision, mpq_class);
+BENCHMARK_TEMPLATE(TrivialDivision, renf_elem_class);
+
+}
+}
+

--- a/libeantic/srcxx/renf_elem_class.cpp
+++ b/libeantic/srcxx/renf_elem_class.cpp
@@ -26,7 +26,8 @@ namespace eantic {
 
 namespace {
 
-renf_elem_class& binop(renf_elem_class& lhs, const renf_elem_class& rhs, const std::function<void(renf_elem_t, const renf_elem_t, const renf_elem_t, renf_t)>& op)
+template <void op(renf_elem_t, const renf_elem_t, const renf_elem_t, const renf_t)>
+renf_elem_class& binop(renf_elem_class& lhs, const renf_elem_class& rhs)
 {
     if (lhs.parent() == rhs.parent())
         op(lhs.renf_elem_t(), lhs.renf_elem_t(), rhs.renf_elem_t(), lhs.parent().renf_t());
@@ -43,7 +44,8 @@ renf_elem_class& binop(renf_elem_class& lhs, const renf_elem_class& rhs, const s
     return lhs;
 }
 
-renf_elem_class& binop_mpz(renf_elem_class& lhs, const mpz_class& rhs, const std::function<void(renf_elem_t, const renf_elem_t, const fmpz_t, renf_t)>& op)
+template <void op(renf_elem_t, const renf_elem_t, const fmpz_t, const renf_t)>
+renf_elem_class& binop_mpz(renf_elem_class& lhs, const mpz_class& rhs)
 {
     ::fmpz_t r;
     fmpz_init_set_readonly(r, rhs.get_mpz_t());
@@ -70,7 +72,8 @@ bool relop_mpz(const renf_elem_class& lhs, const mpz_class& rhs, const int cmp)
     return ret;
 }
 
-renf_elem_class& binop_mpq(renf_elem_class& lhs, const mpq_class& rhs, const std::function<void(renf_elem_t, const renf_elem_t, const fmpq_t, renf_t)>& op)
+template <void op(renf_elem_t, const renf_elem_t, const fmpq_t, const renf_t)>
+renf_elem_class& binop_mpq(renf_elem_class& lhs, const mpq_class& rhs)
 {
     ::fmpq_t r;
     fmpq_init_set_readonly(r, rhs.get_mpq_t());
@@ -646,22 +649,22 @@ renf_elem_class::operator bool() const
 
 renf_elem_class & renf_elem_class::operator+=(const renf_elem_class & rhs)
 {
-    return binop(*this, rhs, renf_elem_add);
+    return binop<renf_elem_add>(*this, rhs);
 }
 
 renf_elem_class & renf_elem_class::operator-=(const renf_elem_class & rhs)
 {
-    return binop(*this, rhs, renf_elem_sub);
+    return binop<renf_elem_sub>(*this, rhs);
 }
 
 renf_elem_class & renf_elem_class::operator*=(const renf_elem_class & rhs)
 {
-    return binop(*this, rhs, renf_elem_mul);
+    return binop<renf_elem_mul>(*this, rhs);
 }
 
 renf_elem_class & renf_elem_class::operator/=(const renf_elem_class & rhs)
 {
-    return binop(*this, rhs, renf_elem_div);
+    return binop<renf_elem_div>(*this, rhs);
 }
 
 mpz_class renf_elem_class::floordiv(const renf_elem_class& rhs) const
@@ -959,22 +962,22 @@ bool operator>(const renf_elem_class& lhs, unsigned long long rhs) {
 
 renf_elem_class& renf_elem_class::operator+=(const mpz_class& rhs)
 {
-    return binop_mpz(*this, rhs, renf_elem_add_fmpz);
+    return binop_mpz<renf_elem_add_fmpz>(*this, rhs);
 }
 
 renf_elem_class& renf_elem_class::operator-=(const mpz_class& rhs)
 {
-    return binop_mpz(*this, rhs, renf_elem_sub_fmpz);
+    return binop_mpz<renf_elem_sub_fmpz>(*this, rhs);
 }
 
 renf_elem_class& renf_elem_class::operator*=(const mpz_class& rhs)
 {
-    return binop_mpz(*this, rhs, renf_elem_mul_fmpz);
+    return binop_mpz<renf_elem_mul_fmpz>(*this, rhs);
 }
 
 renf_elem_class& renf_elem_class::operator/=(const mpz_class& rhs)
 {
-    return binop_mpz(*this, rhs, renf_elem_div_fmpz);
+    return binop_mpz<renf_elem_div_fmpz>(*this, rhs);
 }
 
 bool operator==(const renf_elem_class& lhs, const mpz_class& rhs) {
@@ -991,22 +994,22 @@ bool operator>(const renf_elem_class& lhs, const mpz_class& rhs) {
 
 renf_elem_class& renf_elem_class::operator+=(const mpq_class& rhs)
 {
-    return binop_mpq(*this, rhs, renf_elem_add_fmpq);
+    return binop_mpq<renf_elem_add_fmpq>(*this, rhs);
 }
 
 renf_elem_class& renf_elem_class::operator-=(const mpq_class& rhs)
 {
-    return binop_mpq(*this, rhs, renf_elem_sub_fmpq);
+    return binop_mpq<renf_elem_sub_fmpq>(*this, rhs);
 }
 
 renf_elem_class& renf_elem_class::operator*=(const mpq_class& rhs)
 {
-    return binop_mpq(*this, rhs, renf_elem_mul_fmpq);
+    return binop_mpq<renf_elem_mul_fmpq>(*this, rhs);
 }
 
 renf_elem_class& renf_elem_class::operator/=(const mpq_class& rhs)
 {
-    return binop_mpq(*this, rhs, renf_elem_div_fmpq);
+    return binop_mpq<renf_elem_div_fmpq>(*this, rhs);
 }
 
 bool operator==(const renf_elem_class& lhs, const mpq_class& rhs) {


### PR DESCRIPTION
This saves a few cycles with rather trivial number field elements.

Before:
```
TrivialAddition<renf_elem_class>             63.9 ns         63.9 ns     10316432
TrivialMultiplication<renf_elem_class>       56.8 ns         56.8 ns     13335032
TrivialSubtraction<renf_elem_class>          68.4 ns         68.4 ns     11463610
TrivialDivision<renf_elem_class>              126 ns          126 ns      5095247
```

After:
```
TrivialAddition<renf_elem_class>             56.6 ns         56.6 ns     12140297
TrivialMultiplication<renf_elem_class>       48.2 ns         48.2 ns     14852299
TrivialSubtraction<renf_elem_class>          52.4 ns         52.4 ns     14056737
TrivialDivision<renf_elem_class>              118 ns          118 ns      5972146
```