### PR TITLE
use latest cppyy when testing

### DIFF
--- a/pyeantic/environment.yml
+++ b/pyeantic/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - benchmark
   - boost-cpp
   - coreutils
-  - cppyy>=1.9.2
+  - cppyy>=2.1.0,<3
   - cxx-compiler
   - gmp
   - ipywidgets

--- a/pyeantic/recipe/meta.yaml
+++ b/pyeantic/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - e-antic
   run:
     - python
-    - cppyy
+    - cppyy >=2.1.0,<3
     - cppyythonizations
     - boost-cpp
 


### PR DESCRIPTION
since some intermediate versions have problems with some serializations