### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,23 +114,23 @@ jobs:
       matrix:
         include:
           - on: ubuntu-20.04
-            python: "3.6"
-          - on: ubuntu-20.04
             python: "3.7"
           - on: ubuntu-20.04
             python: "3.8"
           - on: ubuntu-20.04
             python: "3.9"
-          - on: macos-10.15
-            python: "3.6"
+          - on: ubuntu-20.04
+            python: "3.10"
           - on: macos-10.15
             python: "3.7"
           - on: macos-10.15
             python: "3.8"
           - on: macos-10.15
             python: "3.9"
+          - on: macos-10.15
+            python: "3.10"
           - on: ubuntu-20.04
-            python: "3.9"
+            python: "3.10"
             sanitizer: valgrind
           # Needs libsanitizer=11, with the default sanitizer, we get "ASan is ignoring requested __asan_handle_no_return" when importing SageMath and then fail to find the roots of some polynomials.
           # - on: ubuntu-20.04

--- a/libeantic/environment.yml
+++ b/libeantic/environment.yml
@@ -12,7 +12,8 @@ dependencies:
   - benchmark
   - byexample
   - boost-cpp
-  - cppyy
+  # Our byexample setup uses cppyy to run C++ code samples.
+  - cppyy>=2.1.0,<3
   - coreutils
   - c-compiler
   - cxx-compiler

--- a/pyeantic/recipe/conda_build_config.yaml
+++ b/pyeantic/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 # Pins from https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml
 # so our packages is compatible with the choices made by conda-forge.
 python:
-  - 3.6.* *_cpython
   - 3.7.* *_cpython
   - 3.8.* *_cpython
   - 3.9.* *_cpython
+  - 3.10.* *_cpython


### PR DESCRIPTION
and add Python 3.10 support.

We do not really need Python 3.7 we just don't run tests and build conda
packages for 3.6 anymore. Also, we only require Python 3.6 so
distributions that want to support Python 3.6 for longer do not need to
patch our build scripts.

Fixes #215.

This needs the following dependencies:

* [ ] https://github.com/conda-forge/cppyy-feedstock/pull/54