### PR TITLE
Drop support for Python 3.6 and add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,21 +114,21 @@ jobs:
       matrix:
         include:
           - on: ubuntu-20.04
-            python: "3.6"
-          - on: ubuntu-20.04
             python: "3.7"
           - on: ubuntu-20.04
             python: "3.8"
           - on: ubuntu-20.04
             python: "3.9"
-          - on: macos-10.15
-            python: "3.6"
+          - on: ubuntu-20.04
+            python: "3.10"
           - on: macos-10.15
             python: "3.7"
           - on: macos-10.15
             python: "3.8"
           - on: macos-10.15
             python: "3.9"
+          - on: macos-10.15
+            python: "3.10"
           - on: ubuntu-20.04
             python: "3.9"
             sanitizer: valgrind

--- a/doc/news/python310.rst
+++ b/doc/news/python310.rst
@@ -1,0 +1,9 @@
+**Added:**
+
+* Added support for Python 3.10; we are now automatically testing pyeantic with
+  Python 3.10.
+
+**Changed:**
+
+* Dropped explicit support for Python 3.6 which has reached its end of life. It
+  should still work but we are not testing it explicitly in our CI anymore.

--- a/libeantic/environment.yml
+++ b/libeantic/environment.yml
@@ -12,7 +12,8 @@ dependencies:
   - benchmark
   - byexample
   - boost-cpp
-  - cppyy
+  # Our byexample setup uses cppyy to run C++ code samples.
+  - cppyy>=2.1.0,<3
   - coreutils
   - c-compiler
   - cxx-compiler

--- a/pyeantic/recipe/conda_build_config.yaml
+++ b/pyeantic/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 # Pins from https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml
 # so our packages is compatible with the choices made by conda-forge.
 python:
-  - 3.6.* *_cpython
   - 3.7.* *_cpython
   - 3.8.* *_cpython
   - 3.9.* *_cpython
+  - 3.10.* *_cpython


### PR DESCRIPTION
Dependencies:
* [x] https://github.com/conda-forge/cppyy-feedstock/pull/54
* [x] Python 3.10 migration needs to run for sagelib in conda-forge, see https://conda-forge.org/status/#python310
  * [x] i.e., https://github.com/conda-forge/pplpy-feedstock/pull/10