### PR TITLE
Fix import order in setup.py

### DIFF
--- a/doc/news/setup.rst
+++ b/doc/news/setup.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed import order in pyeantic's setup.py script.

--- a/pyeantic/src/setup.py.in
+++ b/pyeantic/src/setup.py.in
@@ -1,12 +1,14 @@
 import os
-from distutils.core import setup
 from setuptools.command.egg_info import egg_info
+from distutils.core import setup
+
 
 class vpath_egg_info(egg_info):
     r"""
     A VPATH aware egg_info for VPATH builds with Automake, see
     https://blog.kevin-brown.com/programming/2014/09/24/combining-autotools-and-setuptools.html
     """
+
     def run(self):
         r"""
         Run egg_info.run() but build the .egg-info in the --build-base path
@@ -18,16 +20,17 @@ class vpath_egg_info(egg_info):
             self.egg_info = os.path.join(self.egg_base, os.path.basename(self.egg_info))
         egg_info.run(self)
 
+
 setup(
-    name = 'pyeantic',
-    version = '@PACKAGE_VERSION@',
-    packages = ['pyeantic',],
-    license = 'GPL 2.0+',
+    name='pyeantic',
+    version='@PACKAGE_VERSION@',
+    packages=['pyeantic'],
+    license='GPL 2.0+',
     install_requires=[
         'cppyy'
     ],
-    long_description = open('@abs_top_srcdir@/../README.md').read(),
+    long_description=open('@abs_top_srcdir@/../README.md').read(),
     include_package_data=True,
-    cmdclass={ 'egg_info': vpath_egg_info },
-    package_dir={ "": os.path.relpath('@abs_top_srcdir@/src/') },
+    cmdclass={'egg_info': vpath_egg_info},
+    package_dir={"": os.path.relpath('@abs_top_srcdir@/src/')},
 )


### PR DESCRIPTION
Importing Setuptools breaks some of distutils so they need to be
imported in the correct order.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test/benchmark for this change. (I don't know how to test this. It's a spurious warning on some versions of distutils.)

<!--
Please add any other relevant info below:
-->

