### PR TITLE
Require parents of binary operations to match

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,7 @@ jobs:
           echo "::set-output name=shared::"`[[ "${{ matrix.sanitizer }}" == "address" ]] && echo "-fsanitize=address -fno-sanitize-recover -fno-omit-frame-pointer"` `[[ "${{ matrix.sanitizer }}" == "undefined" ]] && echo "-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"`
           echo "::set-output name=linker::"`[[ "${{ matrix.sanitizer }}" == "address" ]] && echo "-fsanitize=address"` `[[ "${{ matrix.sanitizer }}" == "undefined" ]] && echo "-fsanitize=undefined"`
       - uses: conda-incubator/setup-miniconda@v2
-        # There are some byexample issues when using Python 3.10 so we stick to 3.9 currently:
-        # on macOS we get "Can't pickle <class 'cxx.CxxInterpreter'>: it's not the same object as cxx.CxxInterpreter"
-        with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true, python-version: "3.9" }
+        with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true }
       - name: install valgrind
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,9 @@ jobs:
           echo "::set-output name=shared::"`[[ "${{ matrix.sanitizer }}" == "address" ]] && echo "-fsanitize=address -fno-sanitize-recover -fno-omit-frame-pointer"` `[[ "${{ matrix.sanitizer }}" == "undefined" ]] && echo "-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"`
           echo "::set-output name=linker::"`[[ "${{ matrix.sanitizer }}" == "address" ]] && echo "-fsanitize=address"` `[[ "${{ matrix.sanitizer }}" == "undefined" ]] && echo "-fsanitize=undefined"`
       - uses: conda-incubator/setup-miniconda@v2
-        with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true }
+        # There are some byexample issues when using Python 3.10 so we stick to 3.9 currently:
+        # on macOS we get "Can't pickle <class 'cxx.CxxInterpreter'>: it's not the same object as cxx.CxxInterpreter"
+        with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true, python-version: "3.9" }
       - name: install valgrind
         shell: bash -l {0}
         run: |

--- a/doc/news/strict-binop.rst
+++ b/doc/news/strict-binop.rst
@@ -1,0 +1,3 @@
+**Deprecated:**
+
+* Deprecated arithmetic between elements in different number fields in the C++ interface. Before, an operation such as `a + b` was possible even if `a` and `b` lived in different number fields if at least one of them was actually a rational number. This led to inconsistent parent fields of the resulting element. We still allow such operations if the parent of `a` or `b` is the rational field (`renf_class::make()`) otherwise a deprecation warning is printed. To fully opt in to the new behaviour set the environment variable `LIBEANTIC_STRICT_BINOP` to any value; this raises an exception instead of printing a warning.

--- a/libeantic/benchmark/renfxx/b-arithmetic.cpp
+++ b/libeantic/benchmark/renfxx/b-arithmetic.cpp
@@ -47,6 +47,16 @@ static void TrivialReverseAddition(State& state)
 }
 BENCHMARK(TrivialReverseAddition)->Arg(1)->Arg(2)->Arg(4);
 
+static void RationalAddition(State& state)
+{
+    renf_elem_class lhs = make_number_field(state.range(0))->gen();
+    renf_elem_class rhs = 2;
+
+    for (auto _ : state)
+        DoNotOptimize(lhs += rhs);
+}
+BENCHMARK(RationalAddition)->Arg(1)->Arg(2)->Arg(4);
+
 template <typename T>
 static void TrivialMultiplication(State& state)
 {
@@ -63,15 +73,25 @@ BENCHMARK_TEMPLATE(TrivialMultiplication, mpz_class)->Arg(1)->Arg(2)->Arg(4);
 BENCHMARK_TEMPLATE(TrivialMultiplication, mpq_class)->Arg(1)->Arg(2)->Arg(4);
 BENCHMARK_TEMPLATE(TrivialMultiplication, renf_elem_class)->Arg(1)->Arg(2)->Arg(4);
 
-static void TrivialReverseSubtraction(State& state)
+static void TrivialReverseMultiplication(State& state)
 {
-    renf_elem_class_pool lhs(state, 2);
+    renf_elem_class_pool lhs(state, -1);
     renf_elem_class rhs = make_number_field(state.range(0))->gen();
 
     for (auto _ : state)
-        DoNotOptimize(lhs() -= rhs);
+        DoNotOptimize(lhs() *= rhs);
 }
-BENCHMARK(TrivialReverseSubtraction)->Arg(1)->Arg(2)->Arg(4);
+BENCHMARK(TrivialReverseMultiplication)->Arg(1)->Arg(2)->Arg(4);
+
+static void RationalMultiplication(State& state)
+{
+    renf_elem_class lhs = make_number_field(state.range(0))->gen();
+    renf_elem_class rhs = -1;
+
+    for (auto _ : state)
+        DoNotOptimize(lhs *= rhs);
+}
+BENCHMARK(RationalMultiplication)->Arg(1)->Arg(2)->Arg(4);
 
 template <typename T>
 static void TrivialSubtraction(State& state)
@@ -89,15 +109,25 @@ BENCHMARK_TEMPLATE(TrivialSubtraction, mpz_class)->Arg(1)->Arg(2)->Arg(4);
 BENCHMARK_TEMPLATE(TrivialSubtraction, mpq_class)->Arg(1)->Arg(2)->Arg(4);
 BENCHMARK_TEMPLATE(TrivialSubtraction, renf_elem_class)->Arg(1)->Arg(2)->Arg(4);
 
-static void TrivialReverseMultiplication(State& state)
+static void TrivialReverseSubtraction(State& state)
 {
-    renf_elem_class_pool lhs(state, -1);
+    renf_elem_class_pool lhs(state, 2);
     renf_elem_class rhs = make_number_field(state.range(0))->gen();
 
     for (auto _ : state)
-        DoNotOptimize(lhs() *= rhs);
+        DoNotOptimize(lhs() -= rhs);
 }
-BENCHMARK(TrivialReverseMultiplication)->Arg(1)->Arg(2)->Arg(4);
+BENCHMARK(TrivialReverseSubtraction)->Arg(1)->Arg(2)->Arg(4);
+
+static void RationalSubtraction(State& state)
+{
+    renf_elem_class lhs = make_number_field(state.range(0))->gen();
+    renf_elem_class rhs = 2;
+
+    for (auto _ : state)
+        DoNotOptimize(lhs -= rhs);
+}
+BENCHMARK(RationalSubtraction)->Arg(1)->Arg(2)->Arg(4);
 
 template <typename T>
 static void TrivialDivision(State& state)
@@ -124,6 +154,16 @@ static void TrivialReverseDivision(State& state)
         DoNotOptimize(lhs() /= rhs);
 }
 BENCHMARK(TrivialReverseDivision)->Arg(1)->Arg(2)->Arg(4);
+
+static void RationalDivision(State& state)
+{
+    renf_elem_class lhs = make_number_field(state.range(0))->gen();
+    renf_elem_class rhs = -1;
+
+    for (auto _ : state)
+        DoNotOptimize(lhs /= rhs);
+}
+BENCHMARK(RationalDivision)->Arg(1)->Arg(2)->Arg(4);
 
 }
 }

--- a/libeantic/environment.yml
+++ b/libeantic/environment.yml
@@ -10,7 +10,9 @@ dependencies:
   - antic
   - automake
   - benchmark
-  - byexample
+  # byexample 10.5 is not working on macOS:
+  # _pickle.PicklingError: Can't pickle <class 'cxx.CxxInterpreter'>: it's not the same object as cxx.CxxInterpreter
+  - byexample>=10.4,<10.5
   - boost-cpp
   # Our byexample setup uses cppyy to run C++ code samples.
   - cppyy>=2.1.0,<3

--- a/libeantic/environment.yml
+++ b/libeantic/environment.yml
@@ -10,8 +10,7 @@ dependencies:
   - antic
   - automake
   - benchmark
-  # byexample 10.5 is not working on macOS:
-  # _pickle.PicklingError: Can't pickle <class 'cxx.CxxInterpreter'>: it's not the same object as cxx.CxxInterpreter
+  # byexample 10.5 is not working on macOS: https://github.com/byexamples/byexample/issues/220
   - byexample>=10.4,<10.5
   - boost-cpp
   # Our byexample setup uses cppyy to run C++ code samples.

--- a/libeantic/srcxx/renf_elem_class.cpp
+++ b/libeantic/srcxx/renf_elem_class.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2018 Vincent Delecroix
-    Copyright (C) 2019-2021 Julian Rüth
+    Copyright (C) 2019-2022 Julian Rüth
 
     This file is part of e-antic
 
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <iostream>
 #include <cassert>
 #include <flint/fmpq.h>
 #include <cstdlib>
@@ -106,20 +107,39 @@ template <
 renf_elem_class& binop(renf_elem_class& lhs, const renf_elem_class& rhs)
 {
     if (lhs.parent() == rhs.parent())
-        renf_op(lhs.renf_elem_t(), lhs.renf_elem_t(), rhs.renf_elem_t(), lhs.parent().renf_t());
-    else if (rhs.is_integer())
-        fmpz_op(lhs.renf_elem_t(), lhs.renf_elem_t(), renf_elem_get_fmpz(rhs.renf_elem_t(), rhs.parent().renf_t()), lhs.parent().renf_t());
-    else if (rhs.is_rational())
     {
-        fmpq_t buffer;
-        fmpq_init(buffer);
-        fmpq_op(lhs.renf_elem_t(), lhs.renf_elem_t(), renf_elem_get_fmpq(buffer, rhs.renf_elem_t(), rhs.parent().renf_t()), lhs.parent().renf_t());
-        fmpq_clear(buffer);
+        renf_op(lhs.renf_elem_t(), lhs.renf_elem_t(), rhs.renf_elem_t(), lhs.parent().renf_t());
     }
     else
     {
-        coerce(lhs, rhs.parent());
-        binop<renf_op, fmpz_op, fmpq_op>(lhs, rhs);
+        if (lhs.parent() != renf_class::make() && rhs.parent() != renf_class::make())
+        {
+            static const char* STRICT_BINOP = getenv("LIBEANTIC_STRICT_BINOP");
+
+            static const char* message = "Performing arithmetic on number field elements in different fields has been deprecated. Make sure to bring the elements into the same field or the rational field explicitly before performing arithmetic on them. See https://github.com/flatsurf/e-antic/issues/126.";
+
+            if (STRICT_BINOP != nullptr)
+                throw std::invalid_argument(message);
+            else
+                std::cerr << message << std::endl;
+        }
+
+        if (rhs.is_integer())
+        {
+            fmpz_op(lhs.renf_elem_t(), lhs.renf_elem_t(), renf_elem_get_fmpz(rhs.renf_elem_t(), rhs.parent().renf_t()), lhs.parent().renf_t());
+        }
+        else if (rhs.is_rational())
+        {
+            fmpq_t buffer;
+            fmpq_init(buffer);
+            fmpq_op(lhs.renf_elem_t(), lhs.renf_elem_t(), renf_elem_get_fmpq(buffer, rhs.renf_elem_t(), rhs.parent().renf_t()), lhs.parent().renf_t());
+            fmpq_clear(buffer);
+        }
+        else
+        {
+            coerce(lhs, rhs.parent());
+            binop<renf_op, fmpz_op, fmpq_op>(lhs, rhs);
+        }
     }
 
     return lhs;

--- a/libeantic/test/byexample/extensions/cxx.py
+++ b/libeantic/test/byexample/extensions/cxx.py
@@ -14,7 +14,7 @@ parsing for us.
 ######################################################################
 #  This file is part of e-antic.
 #
-#        Copyright (C) 2021-2022 Julian Rüth
+#        Copyright (C) 2021 Julian Rüth
 #
 #  e-antic is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Lesser General Public License as published by
@@ -36,7 +36,6 @@ from byexample.common import constant
 import byexample.modules.cpp
 
 stability = 'experimental'
-
 
 class MarkdownCxxDelimiter(ZoneDelimiter):
     r"""
@@ -62,7 +61,6 @@ class MarkdownCxxDelimiter(ZoneDelimiter):
 
     def __repr__(self): return "```c++ ... ``` or ```cpp ... ``` or ```c ... ```"
 
-
 class MarkdownHppDelimiter(ZoneDelimiter):
     r"""
     Detect C/C++ examples in Markdown comments in header files like the ones
@@ -81,13 +79,12 @@ class MarkdownHppDelimiter(ZoneDelimiter):
             # then, grab everything until the first end marker
             (?P<zone>.*?)
             # finally, the end marker
-            (?(marker)
+            (?(marker)   
                   ^[ ]*(?P=marker) # we must match the same amount of backticks
             )
             ''', re.DOTALL | re.MULTILINE | re.VERBOSE)
 
     def __repr__(self): return "/// ``` ... ```"
-
 
 class CxxPromptFinder(byexample.modules.cpp.CppPromptFinder):
     r"""
@@ -131,11 +128,10 @@ class CxxPromptFinder(byexample.modules.cpp.CppPromptFinder):
     def _remove_expected(self, snippet):
         marker = "// -> "
         lines = snippet.split("\n")
-        lines = [line[len(marker):] if line.startswith(marker) else line for line in lines]
+        lines = [ line[len(marker):] if line.startswith(marker) else line for line in lines]
         return '\n'.join(lines)
 
     def __repr__(self): return "Unprefixed C++ Prompt Finder"
-
 
 class CxxInterpreter(byexample.runner.ExampleRunner):
     r"""

--- a/libeantic/test/byexample/extensions/cxx.py
+++ b/libeantic/test/byexample/extensions/cxx.py
@@ -37,6 +37,7 @@ import byexample.modules.cpp
 
 stability = 'experimental'
 
+
 class MarkdownCxxDelimiter(ZoneDelimiter):
     r"""
     Detects C/C++ examples in Markdown.
@@ -61,6 +62,7 @@ class MarkdownCxxDelimiter(ZoneDelimiter):
 
     def __repr__(self): return "```c++ ... ``` or ```cpp ... ``` or ```c ... ```"
 
+
 class MarkdownHppDelimiter(ZoneDelimiter):
     r"""
     Detect C/C++ examples in Markdown comments in header files like the ones
@@ -79,12 +81,13 @@ class MarkdownHppDelimiter(ZoneDelimiter):
             # then, grab everything until the first end marker
             (?P<zone>.*?)
             # finally, the end marker
-            (?(marker)   
+            (?(marker)
                   ^[ ]*(?P=marker) # we must match the same amount of backticks
             )
             ''', re.DOTALL | re.MULTILINE | re.VERBOSE)
 
     def __repr__(self): return "/// ``` ... ```"
+
 
 class CxxPromptFinder(byexample.modules.cpp.CppPromptFinder):
     r"""
@@ -128,10 +131,11 @@ class CxxPromptFinder(byexample.modules.cpp.CppPromptFinder):
     def _remove_expected(self, snippet):
         marker = "// -> "
         lines = snippet.split("\n")
-        lines = [ line[len(marker):] if line.startswith(marker) else line for line in lines]
+        lines = [line[len(marker):] if line.startswith(marker) else line for line in lines]
         return '\n'.join(lines)
 
     def __repr__(self): return "Unprefixed C++ Prompt Finder"
+
 
 class CxxInterpreter(byexample.runner.ExampleRunner):
     r"""

--- a/libeantic/test/byexample/extensions/cxx.py
+++ b/libeantic/test/byexample/extensions/cxx.py
@@ -14,7 +14,7 @@ parsing for us.
 ######################################################################
 #  This file is part of e-antic.
 #
-#        Copyright (C) 2021 Julian Rüth
+#        Copyright (C) 2021-2022 Julian Rüth
 #
 #  e-antic is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Lesser General Public License as published by
@@ -36,6 +36,7 @@ from byexample.common import constant
 import byexample.modules.cpp
 
 stability = 'experimental'
+
 
 class MarkdownCxxDelimiter(ZoneDelimiter):
     r"""
@@ -61,6 +62,7 @@ class MarkdownCxxDelimiter(ZoneDelimiter):
 
     def __repr__(self): return "```c++ ... ``` or ```cpp ... ``` or ```c ... ```"
 
+
 class MarkdownHppDelimiter(ZoneDelimiter):
     r"""
     Detect C/C++ examples in Markdown comments in header files like the ones
@@ -79,12 +81,13 @@ class MarkdownHppDelimiter(ZoneDelimiter):
             # then, grab everything until the first end marker
             (?P<zone>.*?)
             # finally, the end marker
-            (?(marker)   
+            (?(marker)
                   ^[ ]*(?P=marker) # we must match the same amount of backticks
             )
             ''', re.DOTALL | re.MULTILINE | re.VERBOSE)
 
     def __repr__(self): return "/// ``` ... ```"
+
 
 class CxxPromptFinder(byexample.modules.cpp.CppPromptFinder):
     r"""
@@ -128,10 +131,11 @@ class CxxPromptFinder(byexample.modules.cpp.CppPromptFinder):
     def _remove_expected(self, snippet):
         marker = "// -> "
         lines = snippet.split("\n")
-        lines = [ line[len(marker):] if line.startswith(marker) else line for line in lines]
+        lines = [line[len(marker):] if line.startswith(marker) else line for line in lines]
         return '\n'.join(lines)
 
     def __repr__(self): return "Unprefixed C++ Prompt Finder"
+
 
 class CxxInterpreter(byexample.runner.ExampleRunner):
     r"""


### PR DESCRIPTION
and print a deprecation warning if they do not match.

Fixes #126.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test/benchmark for this change.

<!--
Please add any other relevant info below:
-->

