### PR TITLE
Fix deserialization of <1.0.0 cereal objects

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,8 @@ jobs:
             cc: cc
             cpp: cpp
             cxx: c++
-            cflags: -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -Wno-documentation
-            cxxflags: -Werror -Wall -Wextra -pedantic -Wcast-align -Wcast-qual -Wno-sign-compare -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wno-redundant-decls -Wundef -fdiagnostics-show-option -Wconversion -Wshadow-compatible-local -Wno-deprecated -Wno-deprecated-declarations -Wno-float-equal -Wno-documentation
+            cflags: -Werror -Wall -Wextra -pedantic
+            cxxflags: -Werror -Wall -Wextra -pedantic -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wcast-align -Wcast-qual -Wno-sign-compare -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wno-redundant-decls -Wundef -fdiagnostics-show-option -Wconversion -Wshadow-compatible-local -Wno-deprecated -Wno-deprecated-declarations -Wno-float-equal -Wsign-promo -Wstrict-null-sentinel -Wno-documentation
           - compiler: clang
             cc: clang
             cpp: clang-cpp

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
             cpp: clang-cpp
             cxx: clang++
             # We need -Wno-reselved-identifiers since we extend FLINT using their style of having internal functions start with an underscore.
-            cflags: -Werror -Weverything -Wno-padded -Wno-disabled-macro-expansion -Wno-float-equal -Wno-documentation -Wno-reserved-identifier
+            cflags: -Werror -Weverything -Wno-padded -Wno-disabled-macro-expansion -Wno-float-equal -Wno-documentation -Wno-reserved-identifier -Wno-declaration-after-statement
             cxxflags: -Wno-exit-time-destructors -Wno-undefined-func-template -Wno-global-constructors -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-zero-as-null-pointer-constant -Wno-deprecated-declarations -Wno-shadow-field-in-constructor -Wno-documentation
     steps:
       - uses: actions/checkout@v2

--- a/doc/news/cereal-legacy.rst
+++ b/doc/news/cereal-legacy.rst
@@ -1,0 +1,5 @@
+**Fixed:**
+
+* Fixed serialization of `renf_class` with cereal>=1.3.2 (#224)
+
+* Fixed deserialization of objects serialized with e-antic prior to 1.0.0

--- a/libeantic/configure.ac
+++ b/libeantic/configure.ac
@@ -22,6 +22,9 @@ AC_CANONICAL_HOST
 dnl We build our library with libtool.
 LT_INIT
 
+dnl Find a C99 compiler
+AC_PROG_CC_C99
+
 dnl Find C++ Compiler
 AC_PROG_CXX
 

--- a/libeantic/test/renfxx/t-cereal.cpp
+++ b/libeantic/test/renfxx/t-cereal.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2019-2021 Julian Rüth
+    Copyright (C) 2019-2022 Julian Rüth
 
     This file is part of e-antic
 
@@ -59,4 +59,15 @@ TEST_CASE("Serialize and deserialize elements", "[renf_class][renf_elem_class]")
 
     test_serialization(a);
     test_serialization(std::vector<renf_elem_class>{a, a, b});
+}
+
+TEST_CASE("Deserialize elements which were created with e-antic <1") {
+    std::stringstream s;
+    s << R"({"cereal":{"cereal_class_version": 0, "parent": {"shared": 2147483649, "name": "c", "embedding": "[1.979642883761865464752184075553437574753038743897433376 +/- 4.15e-55]", "minpoly": "c^10 - 11*c^8 + 44*c^6 - 77*c^4 + 55*c^2 - 11", "precision": 64}, "value": "292/33*c^9 + 2272/33*c^8 - 804/11*c^7 - 6225/11*c^6 + 6032/33*c^5 + 46124/33*c^4 - 156*c^3 - 39275/33*c^2 + 100/3*c + 307"}})";
+
+    renf_elem_class x;
+    {
+      ::cereal::JSONInputArchive archive(s);
+      archive(x);
+    }
 }


### PR DESCRIPTION
we have lots of these in the flatsurvey database so it is convenient to
be able to restore them.

Also adapt to cereal >=1.3.1, i.e., fixes https://github.com/flatsurf/e-antic/issues/224