### PR TITLE
Fix unpickling of old cereal objects from Python

### DIFF
--- a/doc/news/cereal-no-exception.rst
+++ b/doc/news/cereal-no-exception.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed deserialization of renf_class from old Python pickles. (#242 sometimes crashed when called from Python since cppyy had trouble with the exceptions being thrown.)

--- a/libeantic/e-antic/cereal.hpp
+++ b/libeantic/e-antic/cereal.hpp
@@ -70,12 +70,12 @@ uint32_t getId(Archive& archive, int)
 
     // Pre-1.0.0 (unreleased) versions of serialization used cereal's builtin
     // versioning. We do not use that anymore, so we have to strip it away.
-    if (archive.getNodeName() == "cereal_class_version")
+    if (archive.getNodeName() == std::string{"cereal_class_version"})
       archive.finishNode();
 
     // Pre-1.0.0 (unreleased) version of serialization called the shared
     // pointer "shared" instead of "id" so we accept both here.
-    if (std::string(archive.getNodeName()) == "shared")
+    if (std::string(archive.getNodeName()) == std::string{"shared"})
     {
       archive(cereal::make_nvp("shared", id));
     } else

--- a/libeantic/e-antic/cereal.hpp
+++ b/libeantic/e-antic/cereal.hpp
@@ -52,19 +52,46 @@ void save(Archive & archive, const boost::intrusive_ptr<const renf_class> & self
     }
 }
 
+namespace {
+
+template <class Archive>
+uint32_t getId(Archive& archive, ...)
+{
+    uint32_t id;
+    archive(id);
+
+    return id;
+}
+
+template <class Archive, typename = decltype(std::declval<Archive>().getNodeName())>
+uint32_t getId(Archive& archive, int)
+{
+    uint32_t id;
+
+    // Pre-1.0.0 (unreleased) versions of serialization used cereal's builtin
+    // versioning. We do not use that anymore, so we have to strip it away.
+    if (archive.getNodeName() == "cereal_class_version")
+      archive.finishNode();
+
+    // Pre-1.0.0 (unreleased) version of serialization called the shared
+    // pointer "shared" instead of "id" so we accept both here.
+    if (std::string(archive.getNodeName()) == "shared")
+    {
+      archive(cereal::make_nvp("shared", id));
+    } else
+    {
+      archive(cereal::make_nvp("id", id));
+    }
+
+    return id;
+}
+
+}
+
 template <class Archive>
 void load(Archive & archive, boost::intrusive_ptr<const renf_class> & self)
 {
-    uint32_t id;
-    try {
-      archive(cereal::make_nvp("id", id));
-    }
-    catch(const cereal::Exception&)
-    {
-      // If this object has been serialized with e-antic <1.0.0, the field is
-      // called "shared" instead.
-      archive(cereal::make_nvp("shared", id));
-    }
+    const uint32_t id = getId(archive, 0 /* ignored, needed to prefer the specialized getId over the generic one */);
 
     if ( id & static_cast<unsigned int>(cereal::detail::msb_32bit) )
     {


### PR DESCRIPTION
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test/benchmark for this change.
