### PR TITLE
Do not use flatsurf channel

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,8 +3,8 @@
 # binders.
 name: binder
 channels:
-  - flatsurf
   - conda-forge
+  - defaults
 dependencies:
   - ipywidgets
   - notebook

--- a/doc/news/binder.rst
+++ b/doc/news/binder.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed conda channels used for binder notebooks.


### PR DESCRIPTION
it contains lots of old versions with broken pins. These versions get
randomly pulled in sometimes and cause things to break in quite bizarre
ways.

We release all our packages very frequently, so there is no need to use
nightly releases here.