### PR TITLE
Do not silently pull in dependencies from PyPI in CI

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -13,7 +13,5 @@ dependencies:
   - standardese>=0.6.0
   - sphinx
   - mkdocs>=1.1.0
-  - pip
-  - pip:
-    - linkchecker
-    - sphinx_rtd_theme
+  - linkchecker
+  - sphinx_rtd_theme

--- a/doc/news/pipdeps.rst
+++ b/doc/news/pipdeps.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Improved `environment.yml` files for development to not pull in any incompatible dependencies from PyPI silently

--- a/pyeantic/environment.yml
+++ b/pyeantic/environment.yml
@@ -28,6 +28,4 @@ dependencies:
   - cppyythonizations
   # valgrind is only needed for make check-valgrind
   # - valgrind
-  - pip
-  - pip:
-    - realalg
+  - realalg


### PR DESCRIPTION
since we want (binary) dependencies to always come from conda-forge instead to avoid incompatibilities.

##### Dependencies

* [x] https://github.com/conda-forge/staged-recipes/pull/21366
* [x] https://github.com/conda-forge/staged-recipes/pull/21367