### PR TITLE
Silence compiler warnings about unitialized variables

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -47,7 +47,9 @@ jobs:
           # Strangely, the linkchecker modules are installed writable and linkchecker then refuses to load them.
           chmod -R a-w `python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"` || true
 
-          linkchecker --check-extern http://localhost:8880/e-antic/libeantic
+          # Do not fail if there are 302 redirects.
+          # Ignore missing robots.txt on GMP website.
+          linkchecker --check-extern http://localhost:8880/e-antic/libeantic --no-warnings --no-robots
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -48,8 +48,7 @@ jobs:
           chmod -R a-w `python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"` || true
 
           # Do not fail if there are 302 redirects.
-          # Ignore missing robots.txt on GMP website.
-          linkchecker --check-extern http://localhost:8880/e-antic/libeantic --no-warnings --no-robots
+          linkchecker --check-extern http://localhost:8880/e-antic/libeantic --no-warnings
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@v2
         with: { submodules: recursive }
       - uses: conda-incubator/setup-miniconda@v2
-        with: { miniforge-variant: "Mambaforge", miniforge-version: "latest", python-version: "3.9" }
+        with: { miniforge-variant: "Mambaforge", miniforge-version: "latest", python-version: "3.10" }
       - name: install dependencies
         shell: bash -l {0}
         run: |
+          mamba env update --quiet -n test -f doc/environment.yml
           mamba env update --quiet -n test -f libeantic/environment.yml
           mamba env update --quiet -n test -f pyeantic/environment.yml
-          mamba env update --quiet -n test -f doc/environment.yml
           conda list
       - name: build e-antic
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,9 +259,9 @@ jobs:
       - name: install dependencies
         shell: bash -l {0}
         run: |
+          mamba env update --quiet -n test -f doc/environment.yml
           mamba env update --quiet -n test -f libeantic/environment.yml
           mamba env update --quiet -n test -f pyeantic/environment.yml
-          mamba env update --quiet -n test -f doc/environment.yml
           conda list
       - name: make distcheck
         shell: bash -l {0}

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -8,7 +8,6 @@ name: doc-eantic-build
 channels:
   - saraedum
   - conda-forge
-  - defaults
 dependencies:
   - standardese>=0.6.0
   - sphinx

--- a/doc/news/unitialized.rst
+++ b/doc/news/unitialized.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* Fixed compiler warning about possibly uninitialized variable.
+

--- a/libeantic/environment.yml
+++ b/libeantic/environment.yml
@@ -4,7 +4,6 @@
 name: e-antic-build
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - arb
   - antic

--- a/libeantic/src/fmpq_poly_extra/evaluate.c
+++ b/libeantic/src/fmpq_poly_extra/evaluate.c
@@ -13,7 +13,7 @@
 #include "../e-antic/fmpq_poly_extra.h"
 #include "../e-antic/fmpz_poly_extra.h"
 
-void _fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_limb_signed_t prec)
+static void _fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_limb_signed_t prec)
 {
     _fmpz_poly_evaluate_arf(res, ((pol)->coeffs), fmpq_poly_length(pol), a, prec);
     arf_div_fmpz(res, res, ((pol)->den), prec, 4);
@@ -37,7 +37,7 @@ void fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_
     }
 }
 
-void _fmpq_poly_evaluate_arb(arb_t res, const fmpq_poly_t pol, const arb_t a, mp_limb_signed_t prec)
+static void _fmpq_poly_evaluate_arb(arb_t res, const fmpq_poly_t pol, const arb_t a, mp_limb_signed_t prec)
 {
     _fmpz_poly_evaluate_arb(res, ((pol)->coeffs), fmpq_poly_length(pol), a, prec);
     arb_div_fmpz(res, res, ((pol)->den), prec);

--- a/libeantic/src/fmpq_poly_extra/evaluate.c
+++ b/libeantic/src/fmpq_poly_extra/evaluate.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2016 Vincent Delecroix
+                  2023 Julian Rüth
 
     This file is part of e-antic
 
@@ -12,32 +13,52 @@
 #include "../e-antic/fmpq_poly_extra.h"
 #include "../e-antic/fmpz_poly_extra.h"
 
+void _fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_limb_signed_t prec)
+{
+    _fmpz_poly_evaluate_arf(res, ((pol)->coeffs), fmpq_poly_length(pol), a, prec);
+    arf_div_fmpz(res, res, ((pol)->den), prec, 4);
+}
+
 void fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_limb_signed_t prec)
 {
-    arf_t rres;
+    if (a == res)
+    {
+        arf_t tmp;
+        arf_init(tmp);
 
-    if (a == res) arf_init(rres);
-    else arf_swap(rres,res);
+        _fmpq_poly_evaluate_arf(tmp, pol, a, prec)
+        arf_swap(tmp, res);
 
-    _fmpz_poly_evaluate_arf(rres, ((pol)->coeffs), fmpq_poly_length(pol), a, prec);
-    arf_div_fmpz(rres,rres,((pol)->den),prec,4);
+        arf_clear(tmp);
+    }
+    else
+    {
+        _fmpq_poly_evaluate_arf(res, pol, a, prec)
+    }
+}
 
-    arf_swap(rres,res);
-    if (a == res) arf_clear(rres);
+void _fmpq_poly_evaluate_arb(arb_t res, const fmpq_poly_t pol, const arb_t a, mp_limb_signed_t prec)
+{
+    _fmpz_poly_evaluate_arb(res, ((pol)->coeffs), fmpq_poly_length(pol), a, prec);
+    arb_div_fmpz(res, res, ((pol)->den), prec);
 }
 
 void fmpq_poly_evaluate_arb(arb_t res, const fmpq_poly_t pol, const arb_t a, mp_limb_signed_t prec)
 {
-    arb_t rres;
+    if (a == res)
+    {
+        arb_t tmp;
+        arb_init(tmp);
 
-    if (a == res) arb_init(rres);
-    else arb_swap(rres,res);
+        _fmpq_poly_evaluate_arb(tmp, pol, a, prec)
+        arb_swap(tmp, res);
 
-    _fmpz_poly_evaluate_arb(rres, ((pol)->coeffs), fmpq_poly_length(pol), a, prec);
-    arb_div_fmpz(rres,rres,((pol)->den),prec);
-
-    arb_swap(rres,res);
-    if (a == res) arb_clear(rres);
+        arb_clear(tmp);
+    }
+    else
+    {
+        _fmpq_poly_evaluate_arb(res, pol, a, prec)
+    }
 }
 
 

--- a/libeantic/src/fmpq_poly_extra/evaluate.c
+++ b/libeantic/src/fmpq_poly_extra/evaluate.c
@@ -33,7 +33,7 @@ void fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_
     }
     else
     {
-        _fmpq_poly_evaluate_arf(res, pol, a, prec)
+        _fmpq_poly_evaluate_arf(res, pol, a, prec);
     }
 }
 
@@ -57,7 +57,7 @@ void fmpq_poly_evaluate_arb(arb_t res, const fmpq_poly_t pol, const arb_t a, mp_
     }
     else
     {
-        _fmpq_poly_evaluate_arb(res, pol, a, prec)
+        _fmpq_poly_evaluate_arb(res, pol, a, prec);
     }
 }
 

--- a/libeantic/src/fmpq_poly_extra/evaluate.c
+++ b/libeantic/src/fmpq_poly_extra/evaluate.c
@@ -26,7 +26,7 @@ void fmpq_poly_evaluate_arf(arf_t res, const fmpq_poly_t pol, const arf_t a, mp_
         arf_t tmp;
         arf_init(tmp);
 
-        _fmpq_poly_evaluate_arf(tmp, pol, a, prec)
+        _fmpq_poly_evaluate_arf(tmp, pol, a, prec);
         arf_swap(tmp, res);
 
         arf_clear(tmp);
@@ -50,7 +50,7 @@ void fmpq_poly_evaluate_arb(arb_t res, const fmpq_poly_t pol, const arb_t a, mp_
         arb_t tmp;
         arb_init(tmp);
 
-        _fmpq_poly_evaluate_arb(tmp, pol, a, prec)
+        _fmpq_poly_evaluate_arb(tmp, pol, a, prec);
         arb_swap(tmp, res);
 
         arb_clear(tmp);

--- a/libeantic/src/fmpz_poly_extra/evaluate.c
+++ b/libeantic/src/fmpz_poly_extra/evaluate.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2016 Vincent Delecroix
+                  2023 Julian Rüth
 
     This file is part of e-antic
 
@@ -25,15 +26,20 @@ void _fmpz_poly_evaluate_arb(arb_t res, const fmpz * pol, mp_limb_signed_t len, 
 
 void fmpz_poly_evaluate_arb(arb_t res, const fmpz_poly_t pol, const arb_t a, mp_limb_signed_t prec)
 {
-    arb_t rres;
+    if (a == res)
+    {
+        arb_t tmp;
+        arb_init(tmp);
 
-    if (a == res) arb_init(rres);
-    else arb_swap(rres,res);
+        _fmpz_poly_evaluate_arb(tmp, pol->coeffs, fmpz_poly_length(pol), a, prec);
+        arb_swap(tmp, res);
 
-    _fmpz_poly_evaluate_arb(rres, pol->coeffs, fmpz_poly_length(pol), a, prec);
-
-    arb_swap(rres,res);
-    if (a == res) arb_clear(rres);
+        arb_clear(tmp);
+    }
+    else
+    {
+      _fmpz_poly_evaluate_arb(res, pol->coeffs, fmpz_poly_length(pol), a, prec);
+    }
 }
 
 void _fmpz_poly_evaluate_arf(arf_t res, const fmpz * pol, mp_limb_signed_t len, const arf_t a, mp_limb_signed_t prec)
@@ -50,13 +56,18 @@ void _fmpz_poly_evaluate_arf(arf_t res, const fmpz * pol, mp_limb_signed_t len, 
 
 void fmpz_poly_evaluate_arf(arf_t res, const fmpz_poly_t pol, const arf_t a, mp_limb_signed_t prec)
 {
-    arf_t rres;
+    if (a == res)
+    {
+        arf_t tmp;
+        arf_init(tmp);
 
-    if (a == res) arf_init(rres);
-    else arf_swap(rres,res);
+        _fmpz_poly_evaluate_arf(tmp, pol->coeffs, fmpz_poly_length(pol), a, prec);
+        arf_swap(tmp, res);
 
-    _fmpz_poly_evaluate_arf(rres, pol->coeffs, fmpz_poly_length(pol), a, prec);
-
-    arf_swap(rres,res);
-    if (a == res) arf_clear(rres);
+        arf_clear(tmp);
+    }
+    else
+    {
+        _fmpz_poly_evaluate_arf(res, pol->coeffs, fmpz_poly_length(pol), a, prec);
+    }
 }

--- a/pyeantic/environment.yml
+++ b/pyeantic/environment.yml
@@ -22,8 +22,6 @@ dependencies:
   - sagelib
   # sagelib<9.2 does not explicitly install libiconv which is needed in lots of places.
   - libiconv
-  # work around https://github.com/conda-forge/fontconfig-feedstock/issues/54#issuecomment-1086911517
-  - fontconfig 2.13.96=*_1|<2.13.96
   - sympy
   - cppyythonizations
   # valgrind is only needed for make check-valgrind

--- a/pyeantic/environment.yml
+++ b/pyeantic/environment.yml
@@ -4,7 +4,6 @@
 name: pyeantic-build
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - antic
   - arb

--- a/pyeantic/src/pyeantic/cppyy_eantic.py
+++ b/pyeantic/src/pyeantic/cppyy_eantic.py
@@ -96,7 +96,7 @@ cppyy.py.add_pythonization(filtered("renf_elem_class")(enable_arithmetic), "eant
 
 def enable_intrusive_serialization(proxy, name):
     r"""
-    Enable seralization for an eantic::renf_class& as returned by
+    Enable serialization for an eantic::renf_class& as returned by
     renf_class::parent().
     """
     def reduce(self):


### PR DESCRIPTION
the evaluation code here uses the variable res as a temporary when it is not aliased. Otherwise, it creates a new temporary. This optimization is probably there for a reason but not only the latest GCC finds this confusing and complains about rres being possibly uninitialized. We try to make this easier to read and get rid of the compiler warning.

Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test/benchmark for this change. (There are direct tests for fmpq and enough indirect tests for fmpz that we can maybe skip this.)

