### PR TITLE
Do not set __sig2exc__ if unspported

### DIFF
--- a/doc/news/sig2exc.rst
+++ b/doc/news/sig2exc.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed exception being thrown by PyPy due to https://github.com/wlav/cppyy/issues/209.

--- a/pyeantic/src/pyeantic/cppyy_eantic.py
+++ b/pyeantic/src/pyeantic/cppyy_eantic.py
@@ -151,7 +151,9 @@ cppyy.include("e-antic/cppyy.hpp")
 from cppyy.gbl import eantic, boost
 
 eantic.renf = lambda *args: unwrap_intrusive_ptr(eantic.renf_class.make(*args))
-eantic.renf_class.make.__sig2exc__ = True
+if hasattr(eantic.renf_class.make, "__sig2exc__"):
+    # cppyy on PyPy does not support sig2exc yet, see https://github.com/wlav/cppyy/issues/209
+    eantic.renf_class.make.__sig2exc__ = True
 
 def for_eantic(x):
     r"""


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test/benchmark for this change.  No, I don't think things work great with PyPy anyway. If we ever want to use PyPy ourselves, we'll add proper tests.

<!--
Please add any other relevant info below:
-->

